### PR TITLE
Doctor source flexibility

### DIFF
--- a/scripts/build-att-pixiplus-2.1.0
+++ b/scripts/build-att-pixiplus-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d10112010/attp145rod/webosdoctorp121ewwatt.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A145_JAR_URL="/webosdoctor/rom/pixiplus/px145r0d10112010/attp145rod/webosdoctorp121ewwatt.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121ewwatt-2.1.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -106,10 +112,10 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A145_FILE} ]  && $wget -c ${A145_JAR_URL}  -O downloads/${A145_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A145_JAR_URL}"  -O downloads/${A145_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/build-sprint-pixi-2.1.0
+++ b/scripts/build-sprint-pixi-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
-S145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixi/px145r0d08102010/spr1ntp145rod/webosdoctorp200ewwsprint.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+S145_JAR_URL="/webosdoctor/rom/pixi/px145r0d08102010/spr1ntp145rod/webosdoctorp200ewwsprint.jar"
 
 P210_FILE="webosdoctorp200ewwsprint-2.1.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -112,10 +118,10 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
-[ ! -f downloads/${S145_FILE} ] && $wget -c ${S145_JAR_URL} -O downloads/${S145_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
+[ ! -f downloads/${S145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${S145_JAR_URL}" -O downloads/${S145_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/build-veer-2.2.3
+++ b/scripts/build-veer-2.2.3
@@ -5,6 +5,12 @@
 #  Your mileage may vary
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
 CARRIER="no"
 
 #Check for parameters...
@@ -23,7 +29,7 @@ if [ "$CARRIER" = "no" ] ; then
 fi
 
 if [ "$CARRIER" = "att" ] ; then
-  A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+  A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
   A212_FILE="webosdoctorp160unaatt-2.1.2.jar"
   A212_BUILD="veer-p160una-att-2.1.2"
   A212_MD5="bb2743f0a30abdb62c03b071d149c5a6"
@@ -33,7 +39,7 @@ if [ "$CARRIER" = "att" ] ; then
 fi
 
 if [ "$CARRIER" = "wr" ] ; then
-  W211_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
+  W211_JAR_URL="/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
   W211_FILE="webosdoctorp160una-wr-2.1.1.jar"
   W211_BUILD="veer-p160una-wr-2.1.1"
   W211_MD5="fb6ae25e15c809836bbe73931839ccf0"
@@ -42,7 +48,7 @@ if [ "$CARRIER" = "wr" ] ; then
   VERSION="2.1.1"
 fi
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
 W224_BUILD="pre2-p224pre2-wr-2.2.4"
 W224_MD5="ea0cb312cb92c1e4d7f1d70820923538"
@@ -126,13 +132,13 @@ mkdir -p downloads
 echo "Will download if needed Veer ${CARRIER} webOS ${VERSION} Doctor"
 case $CARRIER in
     "att" )
-        [ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+        [ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
         [ $(md5sum downloads/${A212_FILE} | cut -d \  -f 1) != ${A212_MD5} ] && \
         echo "${A212_FILE} did not download properly.  Please run this script again." && \
         rm -f downloads/${A212_FILE} && exit
 	;;
     "wr" )
-        [ ! -f downloads/${W211_FILE} ] && $wget -c ${W211_JAR_URL} -O downloads/${W211_FILE}
+        [ ! -f downloads/${W211_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W211_JAR_URL}" -O downloads/${W211_FILE}
         [ $(md5sum downloads/${W211_FILE} | cut -d \  -f 1) != ${W211_MD5} ] && \
         echo "${W211_FILE} did not download properly.  Please run this script again." && \
         rm -f downloads/${W211_FILE} && exit	
@@ -140,7 +146,7 @@ case $CARRIER in
 esac
 
 echo "Will download if needed Pre2 webOS 2.2.4 Doctor"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \
         rm -f downloads/${W224_FILE} && exit

--- a/scripts/build-veer-2.2.4
+++ b/scripts/build-veer-2.2.4
@@ -5,6 +5,12 @@
 #  Your mileage may vary
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
 CARRIER="no"
 
 #Check for parameters...
@@ -23,7 +29,7 @@ if [ "$CARRIER" = "no" ] ; then
 fi
 
 if [ "$CARRIER" = "att" ] ; then
-  A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+  A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
   A212_FILE="webosdoctorp160unaatt-2.1.2.jar"
   A212_BUILD="veer-p160una-att-2.1.2"
   A212_MD5="bb2743f0a30abdb62c03b071d149c5a6"
@@ -33,7 +39,7 @@ if [ "$CARRIER" = "att" ] ; then
 fi
 
 if [ "$CARRIER" = "wr" ] ; then
-  W211_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
+  W211_JAR_URL="/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
   W211_FILE="webosdoctorp160una-wr-2.1.1.jar"
   W211_BUILD="veer-p160una-wr-2.1.1"
   W211_MD5="fb6ae25e15c809836bbe73931839ccf0"
@@ -116,13 +122,13 @@ mkdir -p downloads
 echo "Will download if needed Veer ${CARRIER} webOS ${VERSION} Doctor"
 case $CARRIER in
     "att" )
-        [ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+        [ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
         [ $(md5sum downloads/${A212_FILE} | cut -d \  -f 1) != ${A212_MD5} ] && \
         echo "${A212_FILE} did not download properly.  Please run this script again." && \
         rm -f downloads/${A212_FILE} && exit
 	;;
     "wr" )
-        [ ! -f downloads/${W211_FILE} ] && $wget -c ${W211_JAR_URL} -O downloads/${W211_FILE}
+        [ ! -f downloads/${W211_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W211_JAR_URL}" -O downloads/${W211_FILE}
         [ $(md5sum downloads/${W211_FILE} | cut -d \  -f 1) != ${W211_MD5} ] && \
         echo "${W211_FILE} did not download properly.  Please run this script again." && \
         rm -f downloads/${W211_FILE} && exit	

--- a/scripts/build-verizon-pixiplus-2.1.0
+++ b/scripts/build-verizon-pixiplus-2.1.0
@@ -7,9 +7,15 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121ewwverizonwireless-2.1.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -96,9 +102,9 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/build-wr-pixiplus-2.1.0
+++ b/scripts/build-wr-pixiplus-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+W145_JAR_URL="/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121ewweu-wr-2.1.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -93,10 +99,10 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${W145_FILE} ]  && $wget -c ${W145_JAR_URL}  -O downloads/${W145_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}"  -O downloads/${W145_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -21,11 +21,11 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 ###########################################
 #
 # palm.si server, last checked Sept. 2017
-# Un-comment line below and DOCTOR_SOURCE_HOST to switch to palm.si source.
+# Un-comment line below to switch to palm.si source.
 #DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
 #
-# downloads.help.palm.si will resolve normally, but for use in these scripts,
-# the line below should be un-commented
+# downloads.help.palm.si will resolve normally, but if required, the line
+# below could be un-commented to supply a custom Host header
 #DOCTOR_SOURCE_HOST = "downloads.help.palm.si"
 #
 #########################################
@@ -35,15 +35,12 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 # Here we generate the leading portion of the wget arguments: DOCTOR_SOURCE_OPTS_AND_DOMAIN
 # If DOCTOR_SOURCE_HOST has been defined we include the --header option.
 # If DOCTOR_SOURCE_HOST has NOT been defined we only include the domain.
-# DOCTOR_SOURCE_OPTS_AND_DOMAIN
+# DOCTOR_SOURCE_OPTS_AND_DOMAIN will then be used by meta-doctor scripts.
 if [ -n "${DOCTOR_SOURCE_HOST+1}" ]; then
-  DOCTOR_SOURCE_OPTS_AND_DOMAIN='--header "Host: '${DOCTOR_SOURCE_HOST}" ${DOCTOR_SOURCE_DOMAIN}
+  DOCTOR_SOURCE_OPTS_AND_DOMAIN="--header \"Host: ${DOCTOR_SOURCE_HOST}\" ${DOCTOR_SOURCE_DOMAIN}"
 else
   DOCTOR_SOURCE_OPTS_AND_DOMAIN=${DOCTOR_SOURCE_DOMAIN}
 fi
-# BB TEMP test
-echo ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}
-
 
 ##############################################
 ## START OF ORIGINAL PALM URL DOCUMENTATION ##

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -10,13 +10,14 @@
 # variables in this sub-script hopes to simplify future adjustments that 
 # may be required.
 
-# Default wget option for meta-doctor scripts - Do Not comment-out this assignment
+# Default wget option for meta-doctor scripts - Do Not comment-out this initial assignment
 DOCTOR_SOURCE_WGET_OPTS=( -c )
 
 # "Palm" server at 195.22.200.42, last checked Sept. 2017
 DOCTOR_SOURCE_DOMAIN="http://195.22.200.42"
 
 # Palm server does not have normal DNS resolution, so the HOST header needs to be supplied
+# Comment-out the line below or modify it to provide alternate wget options.
 DOCTOR_SOURCE_WGET_OPTS=(-c '--header=Host: downloads.help.palm.com')
 
 ###########################################
@@ -28,7 +29,7 @@ DOCTOR_SOURCE_WGET_OPTS=(-c '--header=Host: downloads.help.palm.com')
 #DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
 #
 # downloads.help.palm.si will resolve normally, but if required, the line
-# below could be un-commented to supply a custom Host header
+# below could be un-commented to supply a custom Host header and/or other wget options
 #DOCTOR_SOURCE_WGET_OPTS=(-c '--header=Host: downloads.help.palm.si')
 #
 #########################################

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -32,6 +32,19 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 ## END OF EXAMPLE FOR ALTERNATE MIRROR ##
 #########################################
 
+# Here we generate the leading portion of the wget arguments: DOCTOR_SOURCE_OPTS_AND_DOMAIN
+# If DOCTOR_SOURCE_HOST has been defined we include the --header option.
+# If DOCTOR_SOURCE_HOST has NOT been defined we only include the domain.
+# DOCTOR_SOURCE_OPTS_AND_DOMAIN
+if [ -n "${DOCTOR_SOURCE_HOST+1}" ]; then
+  DOCTOR_SOURCE_OPTS_AND_DOMAIN='--header "Host: '${DOCTOR_SOURCE_HOST}" ${DOCTOR_SOURCE_DOMAIN}
+else
+  DOCTOR_SOURCE_OPTS_AND_DOMAIN=${DOCTOR_SOURCE_DOMAIN}
+fi
+# BB TEMP test
+echo ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}
+
+
 ##############################################
 ## START OF ORIGINAL PALM URL DOCUMENTATION ##
 ##############################################

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -1,0 +1,24 @@
+#!/bin/sh
+# This file holds variables to be loaded into meta-doctor scripts
+# to provide a single file that can be used to change the source
+# of Doctors for all scripts.
+# As of 17 September 2017 webOS Doctor jar files can still be
+# pulled from "Palm" servers (downloads.help.palm.com), but a 
+# mirror is also currently available at palm.si (downloads.help.palm.si)
+#
+# Providing the DOCTOR_SOURCE_DOMAIN and DOCTOR_SOURCE_HOST
+# variables in this sub-script hopes to simplify future adjustments that 
+# may be required.
+
+# "Palm" server at 195.22.200.42, last checked Sept. 2017
+DOCTOR_SOURCE_DOMAIN = "http://195.22.200.42"
+
+# palm.si server, last checked Sept. 2017
+#DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
+
+# Palm server does not have normal DNS resolution, so the HOST header needs to be supplied
+DOCTOR_SOURCE_HOST = "downloads.help.palm.com"
+
+# downloads.help.palm.si will resolve normally, but for use in these scripts,
+# the line below should be un-commented
+#DOCTOR_SOURCE_HOST = "downloads.help.palm.si"

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -13,15 +13,24 @@
 # "Palm" server at 195.22.200.42, last checked Sept. 2017
 DOCTOR_SOURCE_DOMAIN="http://195.22.200.42"
 
-# palm.si server, last checked Sept. 2017
-#DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
-
 # Palm server does not have normal DNS resolution, so the HOST header needs to be supplied
 DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 
+###########################################
+## START OF EXAMPLE FOR ALTERNATE MIRROR ##
+###########################################
+#
+# palm.si server, last checked Sept. 2017
+# Un-comment line below and DOCTOR_SOURCE_HOST to switch to palm.si source.
+#DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
+#
 # downloads.help.palm.si will resolve normally, but for use in these scripts,
 # the line below should be un-commented
 #DOCTOR_SOURCE_HOST = "downloads.help.palm.si"
+#
+#########################################
+## END OF EXAMPLE FOR ALTERNATE MIRROR ##
+#########################################
 
 ##############################################
 ## START OF ORIGINAL PALM URL DOCUMENTATION ##

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -11,13 +11,13 @@
 # may be required.
 
 # "Palm" server at 195.22.200.42, last checked Sept. 2017
-DOCTOR_SOURCE_DOMAIN = "http://195.22.200.42"
+DOCTOR_SOURCE_DOMAIN="http://195.22.200.42"
 
 # palm.si server, last checked Sept. 2017
 #DOCTOR_SOURCE_DOMAIN = "http://downloads.help.palm.si"
 
 # Palm server does not have normal DNS resolution, so the HOST header needs to be supplied
-DOCTOR_SOURCE_HOST = "downloads.help.palm.com"
+DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 
 # downloads.help.palm.si will resolve normally, but for use in these scripts,
 # the line below should be un-commented

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This file holds variables to be loaded into meta-doctor scripts
 # to provide a single file that can be used to change the source
 # of Doctors for all scripts.
@@ -6,15 +6,18 @@
 # pulled from "Palm" servers (downloads.help.palm.com), but a 
 # mirror is also currently available at palm.si (downloads.help.palm.si)
 #
-# Providing the DOCTOR_SOURCE_DOMAIN and DOCTOR_SOURCE_HOST
+# Providing the DOCTOR_SOURCE_DOMAIN and DOCTOR_SOURCE_WGET_OPTS
 # variables in this sub-script hopes to simplify future adjustments that 
 # may be required.
+
+# Default wget option for meta-doctor scripts - Do Not comment-out this assignment
+DOCTOR_SOURCE_WGET_OPTS=( -c )
 
 # "Palm" server at 195.22.200.42, last checked Sept. 2017
 DOCTOR_SOURCE_DOMAIN="http://195.22.200.42"
 
 # Palm server does not have normal DNS resolution, so the HOST header needs to be supplied
-DOCTOR_SOURCE_HOST="downloads.help.palm.com"
+DOCTOR_SOURCE_WGET_OPTS=(-c '--header=Host: downloads.help.palm.com')
 
 ###########################################
 ## START OF EXAMPLE FOR ALTERNATE MIRROR ##
@@ -26,7 +29,7 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 #
 # downloads.help.palm.si will resolve normally, but if required, the line
 # below could be un-commented to supply a custom Host header
-#DOCTOR_SOURCE_HOST = "downloads.help.palm.si"
+#DOCTOR_SOURCE_WGET_OPTS=(-c '--header=Host: downloads.help.palm.si')
 #
 #########################################
 ## END OF EXAMPLE FOR ALTERNATE MIRROR ##
@@ -36,11 +39,11 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 # If DOCTOR_SOURCE_HOST has been defined we include the --header option.
 # If DOCTOR_SOURCE_HOST has NOT been defined we only include the domain.
 # DOCTOR_SOURCE_OPTS_AND_DOMAIN will then be used by meta-doctor scripts.
-if [ -n "${DOCTOR_SOURCE_HOST+1}" ]; then
-  DOCTOR_SOURCE_OPTS_AND_DOMAIN="--header \"Host: ${DOCTOR_SOURCE_HOST}\" ${DOCTOR_SOURCE_DOMAIN}"
-else
-  DOCTOR_SOURCE_OPTS_AND_DOMAIN=${DOCTOR_SOURCE_DOMAIN}
-fi
+#if [ -n "${DOCTOR_SOURCE_HOST+1}" ]; then
+#  DOCTOR_SOURCE_OPTS_AND_DOMAIN="--header \"Host: ${DOCTOR_SOURCE_HOST}\" ${DOCTOR_SOURCE_DOMAIN}"
+#else
+#  DOCTOR_SOURCE_OPTS_AND_DOMAIN=${DOCTOR_SOURCE_DOMAIN}
+#fi
 
 ##############################################
 ## START OF ORIGINAL PALM URL DOCUMENTATION ##

--- a/scripts/doctor-source
+++ b/scripts/doctor-source
@@ -22,3 +22,165 @@ DOCTOR_SOURCE_HOST="downloads.help.palm.com"
 # downloads.help.palm.si will resolve normally, but for use in these scripts,
 # the line below should be un-commented
 #DOCTOR_SOURCE_HOST = "downloads.help.palm.si"
+
+##############################################
+## START OF ORIGINAL PALM URL DOCUMENTATION ##
+##############################################
+## FROM http://www.webos-internals.org/wiki/WebOS_Doctor_Versions
+##############################################
+# TOUCHPADS
+# ############################################
+# > Wifi Only - HSTNH-I29C
+# version 3.0.0 http://downloads.help.palm.com/webosdoctor/rom/touchpad/wd300wifi/webosdoctorp300hstnhwifi.jar
+# version 3.0.2 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p302r0d08012011/wifip302rod/webosdoctorp302hstnhwifi.jar
+# version 3.0.4 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar
+# version 3.0.5 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p305rod01122012/wd305wifi/webosdoctorp305hstnhwifi.jar
+# > AT&T 3G - HSTNH-I30C
+# version 3.0.2-66 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p302rod09232011/wd302att/webosdoctorp302hstnhatt.jar
+# version 3.0.2-74 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p302rod10102011/wd302att/webosdoctorp302hstnhatt.jar
+# version 3.0.4 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod10182011/wd304att/webosdoctorp304hstnhatt.jar
+# version 3.0.4-78 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod11152011/wd304att/webosdoctorp304hstnhatt.jar
+# version 3.0.5 http://downloads.help.palm.com/webosdoctor/rom/touchpad/p305rod01122012/wd305att/webosdoctorp305hstnhatt.jar
+# ############################################
+# PHONES
+# ############################################
+# > Sprint
+# >> Pre - P100EWW: P5PE0XXXXXXX
+# * Only Versions 1.4.1.1 & 1.4.5 are available on 20 Sept 2017 from Palm URLs *
+# version 1.2.1 http://downloads.help.palm.com/webosdoctor/rom/p121r0d10092009/sr1ntp121rod/webosdoctorp100ewwsprint.jar
+# version 1.3.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p131r0d11172009/sr1ntp131rod/webosdoctorp100ewwsprint.jar
+# version 1.3.5 http://downloads.help.palm.com/webosdoctor/rom/pre/p135r0d12302009/sr1ntp135rod/webosdoctorp100ewwsprint.jar
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p1351r0d01082010/sr1ntp1351rod/webosdoctorp100ewwsprint.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/sr1ntp140rod/webosdoctorp100ewwsprint.jar
+# version 1.4.1.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p1411r0d03312010/sr1ntp1411rod/webosdoctorp100ewwsprint.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar
+# > Sprint
+# >> Pixi - P120EWW: P6P20XXXXXXX
+# * Only Versions 1.4.1.1 & 1.4.5 are available on 20 Sept 2017 from Palm URLs *
+# version 1.3.1 http://downloads.help.palm.com/webosdoctor/rom/pixi/px131r0d11172009/sr1ntp131rod/webosdoctorp200ewwsprint.jar
+# version 1.3.2 http://downloads.help.palm.com/webosdoctor/rom/pixi/px132r0d12032009/sr1ntp132rod/webosdoctorp200ewwsprint.jar
+# version 1.3.5 http://downloads.help.palm.com/webosdoctor/rom/pixi/px135r0d12302009/sr1ntp135rod/webosdoctorp200ewwsprint.jar
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pixi/px1351r0d01082010/sr1ntp1351rod/webosdoctorp120ewwsprint.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pixi/px14r0d02252010/sr1ntp140rod/webosdoctorp200ewwsprint.jar
+# version 1.4.1.1 http://downloads.help.palm.com/webosdoctor/rom/pixi/px1411r0d03312010/sr1ntp1411rod/webosdoctorp200ewwsprint.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixi/px145r0d08102010/spr1ntp145rod/webosdoctorp200ewwsprint.jar
+# (Palm changed p200eww to p120eww in version 1.3.5.1) (Palm changed p120eww back to p200eww in version 1.4.0) 
+# > Bell Mobility
+# >> Pre - P100EWW: P5BE0XXXXXXX
+# * Only Versions 1.4.1 & 1.4.5 are available on 20 Sept 2017 from Palm URLs *
+# version 1.2.1 http://downloads.help.palm.com/webosdoctor/rom/p121r0d10092009/b11ep121rod/webosdoctorp100ewwbellmo.jar
+# version 1.3.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p131r0d11172009/b11ep131rod/webosdoctorp100ewwbellmo.jar
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p1351r0d01082010/b11ep1351rod/webosdoctorp100ewwbellmo.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/b11ep140rod/webosdoctorp100ewwbellmo.jar
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p141r0d03312010/b11ep141rod/webosdoctorp100ewwbellmo.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d07142010/b11ep145rod/webosdoctorp100ewwbellmo.jar
+# > O2 Germany, UK and Ireland / Movistar Spain
+# >> Pre -  P100UEU: P5FU0XXXXXXX (Pre on the Movistar network), P100UEU: P5HUGXXXXXXX (Pre on the o2 network)
+# * Only Versions 1.4.1 & 1.4.5 are available on 20 Sept 2017 from Palm URLs *
+# version 1.1.3 http://downloads.help.palm.com/webosdoctor/rom/p113r0d10122009/wr640xdfgy12z/webosdoctorp100eww-wr.jar
+# version 1.3.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p131r0d11172009/wrep131rod/webosdoctorp100ueu-wr.jar
+# version 1.3.5.2 http://downloads.help.palm.com/webosdoctor/rom/pre/p1352r0d01182010/wrep1352rod/webosdoctorp100ueu-wr.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/wrep140rod/webosdoctorp100ueu-wr.jar
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p141r0d03312010/eudep141rod/webosdoctorp100ueu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar
+# > O2 Germany, UK and Ireland / Movistar Spain
+# >> Pre Plus
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/preplus/p141r0d04272010/wrep141rod/webosdoctorp101ueu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d06302010/eudep145rod/webosdoctorp101ueu-wr.jar
+# version 2.1.0 (DE) http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d02212011/eudep210rod/webosdoctorp101ueude-wr.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar
+# > O2 Germany, UK and Ireland / Movistar Spain
+# >> Pixi Plus - P121UEU: P8GUGXXXXXXX (Pixi Plus)
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px141r0d04282010/wrep141rod/webosdoctorp121ewweu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar
+# > O2 Germany, UK and Ireland / Movistar Spain
+# >> Veer - P160UEU: W3UE1XXXXXXX (Veer)
+# version 2.1.1 http://downloads.help.palm.com/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar
+# > Vodafone Europe
+# >> Pixi Plus - P121UEU: P8GUGXXXXXXX (Pixi Plus)
+# version 1.4.1.2 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1412r0d04282010/wrep1412rod/webosdoctorp121ewweu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar
+# > Vodafone Europe
+# >> Pre Plus - P101UEU: P7NUGXXXXXXX (Pre Plus on the Vodafone network)
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d06302010/eudep145rod/webosdoctorp101ueu-wr.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d02212011/eudep210rod/webosdoctorp101ueude-wr.jar
+# > SFR France
+# >> Pre Plus - P101UEU: P7JUAXXXXXXX (Pre Plus on the SFR network)
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/preplus/p141r0d04272010/wrep141rod/webosdoctorp101ueu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d06302010/eudep145rod/webosdoctorp101ueu-wr.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar
+# > SFR France
+# >> Pixi Plus
+# version 1.4.1 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px141r0d04272010/wrep141rod/webosdoctorp121ueu-wr.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar
+# > SFR France
+# >> Pre 2
+# version 2.0.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p20r0d11012010/wrep20rod/webosdoctorp103ueu-wr.jar
+# version 2.0.1 http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar
+# > Telcel GSM, Mexico
+# >> Pre - P100UNA: P5XU0XXXXXXX (Pre on the Telcel network)
+# * Only Version 1.4.0 is available on 20 Sept 2017 from Palm URLs *
+# version 1.2.5 http://downloads.help.palm.com/webosdoctor/rom/pre/p125r0d11252009/tce11p125rod/webosdoctorp100ewwtelcel.jar
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p1351r0d01082010/tce11p1351rod/webosdoctorp100ewwtelcel.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/tce11p140rod/webosdoctorp100ewwtelcel.jar (P100UNA/ROW)
+# > Verizon Wireless
+# >> Pre Plus - P101EWW: P7VE0XXXXXXX (Pre Plus on the Verizon network)
+# * Version 1.3.5.1 is NOT available on 20 Sept 2017 from Palm URLs *
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pre/p1351r0d01082010/ver1z0np1351rod/webosdoctorp101ewwverizonwireless.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/ver1z0np140rod/webosdoctorp101ewwverizonwireless.jar
+# version 1.4.1.1 http://downloads.help.palm.com/webosdoctor/rom/preplus/p1411r0d04282010/ver1z0np1411rod/webosdoctorp101ewwverizonwireless.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d09132010/ver1z0np145rod/webosdoctorp101ewwverizonwireless.jar
+# version 1.4.5.1 http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar
+# > Verizon Wireless
+# >> Pixi Plus - P121EWW: P8V20XXXXXXX (Pixi Plus on the Verizon network)
+# * Version 1.3.5.1 is NOT available on 20 Sept 2017 from Palm URLs *
+# version 1.3.5.1 http://downloads.help.palm.com/webosdoctor/rom/pixi/px1351r0d01082010/ver1z0np1351rod/webosdoctorp121ewwverizonwireless.jar
+# version 1.4.0 http://downloads.help.palm.com/webosdoctor/rom/pixi/px14r0d02252010/ver1z0np140rod/webosdoctorp121ewwverizonwireless.jar
+# version 1.4.1.1 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1411r0d04282010/ver1z0np1411rod/webosdoctorp121ewwverizonwireless.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d08302010/ver1z0np145rod/webosdoctorp121ewwverizonwireless.jar
+# version 1.4.5.1 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar
+# > Verizon Wireless
+# >> Pre 2 - P102EWW: PGVE0XXXXXXX (Pre 2 on the Verizon network)
+# version 2.0.1 http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar
+# > Verizon Wireless
+# >> Pre 3 - HSTNH-F30CV: MDVPWXXXXXXX (Pre 3 on the verizon network)
+# version 2.2.3 http://downloads.help.palm.com/webosdoctor/rom/manta/p223r0d09292011/wdmantaverizon/webosdoctorp223mantaverizon.jar
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar
+# > AT&T
+# >> Pre Plus - P101UNA : P7CG0XXXXXXX (Pre Plus on the AT&T network)
+# version 1.4.2 http://downloads.help.palm.com/webosdoctor/rom/preplus/p142r0d05162010/attp142rod/webosdoctorp101ewwatt.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d09132010/attp145rod/webosdoctorp101ewwatt.jar
+# > AT&T
+# >> Pixi Plus - P121UNA: P8WU0XXXXXXX (Pixi Plus on the AT&T network)
+# version 1.4.3 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px143r0d06062010/attp143rod/webosdoctorp121ewwatt.jar
+# version 1.4.5 http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d10112010/attp145rod/webosdoctorp121ewwatt.jar
+# > AT&T
+# >> Veer - P160UNA: W1BD6XXXXXXX (Veer on the AT&T network)
+# version 2.1.2 http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar
+# > AT&T
+# >> Pre 3  -HSTNH-F30CN: W3BD1XXXXXXX
+# version 2.2.3 http://downloads.help.palm.com/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar
+# > Rogers
+# >> Pre 2
+# version 2.0.1 http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d03082011/wrep210rod/webosdoctorp104ueu-wr.jar (P102UEU/P102UNA,ROW)
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar (P102UEU/P102UNA,ROW)
+# > Unlocked
+# >> Pre 2 - P102UEU: PG4U0XXXXXXX (Europe network), P102UNA: PG9U0XXXXXXX (North America network)
+# version 2.0.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p20r0d11012010/wrep20rod/webosdoctorp103ueu-wr.jar (P102UEU only)
+# version 2.0.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p20r0d11182010/wrep20rod/webosdoctorp103ueu-wr.jar (P102UEU & P102UNA)
+# version 2.0.1 http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar (P102UEU & P102UNA)
+# version 2.1.0 http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar (P102UEU/P102UNA,ROW)
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar (P102UEU/P102UNA,ROW)
+# (Palm changed p103ueu to p102ueuna in 2.0.1) (Palm changed p102ueuna to p103ueuna in 2.1.0) (Palm changed p103ueuna to p224pre2 in 2.2.4) 
+# > Unlocked
+# >> Pre 3 - HSTNH-F30CE: W3RE1XXXXXXX (Pre 3 Unlocked - Europe network - ROW)
+# version 2.2.0 http://downloads.help.palm.com/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar
+# version 2.2.4 http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantawr/webosdoctorp224mantawr.jar
+############################################
+## END OF ORIGINAL PALM URL DOCUMENTATION ##
+############################################

--- a/scripts/meta-att-franken-tts-veer-2.1.2
+++ b/scripts/meta-att-franken-tts-veer-2.1.2
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
-P304_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+P304_JAR_URL="/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar"
 
 A212_FILE="webosdoctorp160unaatt-2.1.2.jar"
 P304_FILE="webosdoctorp304hstnhwifi-3.0.4.jar"
@@ -68,8 +74,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
-[ ! -f downloads/${P304_FILE} ] && $wget -c ${P304_JAR_URL} -O downloads/${P304_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
+[ ! -f downloads/${P304_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${P304_JAR_URL}" -O downloads/${P304_FILE}
 
 [ $(md5sum downloads/${A212_FILE} | cut -d \  -f 1) != ${A212_MD5} ] && \
         echo "${A212_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-pre3-impersonate-wr-2.2.4
+++ b/scripts/meta-att-pre3-impersonate-wr-2.2.4
@@ -5,7 +5,13 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantawr/webosdoctorp224mantawr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantawr/webosdoctorp224mantawr.jar"
 
 W224_FILE="webosdoctorp224manta-wr-2.2.4.jar"
 
@@ -61,7 +67,7 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-pre3-vanilla-2.2.3
+++ b/scripts/meta-att-pre3-vanilla-2.2.3
@@ -5,8 +5,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W220_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
-A223_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W220_JAR_URL="/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
+A223_JAR_URL="/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar"
 
 W220_FILE="webosdoctorp220manta-wr-2.2.0.jar"
 A223_FILE="webosdoctorp223mantaatt-2.2.3.jar"
@@ -79,8 +85,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W220_FILE} ] && $wget -c ${W220_JAR_URL} -O downloads/${W220_FILE}
-[ ! -f downloads/${A223_FILE} ] && $wget -c ${A223_JAR_URL} -O downloads/${A223_FILE}
+[ ! -f downloads/${W220_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W220_JAR_URL}" -O downloads/${W220_FILE}
+[ ! -f downloads/${A223_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A223_JAR_URL}" -O downloads/${A223_FILE}
 
 [ $(md5sum downloads/${W220_FILE} | cut -d \  -f 1) != ${W220_MD5} ] && \
         echo "${W220_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-pre3-vanilla-2.2.4
+++ b/scripts/meta-att-pre3-vanilla-2.2.4
@@ -5,8 +5,8 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W220_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
-A224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
+W220_JAR_URL="/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
+A224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
 
 W220_FILE="webosdoctorp220manta-wr-2.2.0.jar"
 A224_FILE="webosdoctorp224mantaatt-2.2.4.jar"
@@ -79,8 +79,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W220_FILE} ] && $wget -c ${W220_JAR_URL} -O downloads/${W220_FILE}
-[ ! -f downloads/${A224_FILE} ] && $wget -c ${A224_JAR_URL} -O downloads/${A224_FILE}
+[ ! -f downloads/${W220_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W220_JAR_URL}" -O downloads/${W220_FILE}
+[ ! -f downloads/${A224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A224_JAR_URL}" -O downloads/${A224_FILE}
 
 [ $(md5sum downloads/${W220_FILE} | cut -d \  -f 1) != ${W220_MD5} ] && \
         echo "${W220_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-preplus-2.1.0
+++ b/scripts/meta-att-preplus-2.1.0
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d09132010/attp145rod/webosdoctorp101ewwatt.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/preplus/p145r0d09132010/attp145rod/webosdoctorp101ewwatt.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W145_FILE="webosdoctorp101ewwatt-1.4.5.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -67,8 +73,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-touchpad-3.0.4
+++ b/scripts/meta-att-touchpad-3.0.4
@@ -5,8 +5,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-A302_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/touchpad/p302rod10102011/wd302att/webosdoctorp302hstnhatt.jar"
-A304_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod10182011/wd304att/webosdoctorp304hstnhatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+A302_JAR_URL="/webosdoctor/rom/touchpad/p302rod10102011/wd302att/webosdoctorp302hstnhatt.jar"
+A304_JAR_URL="/webosdoctor/rom/touchpad/p304rod10182011/wd304att/webosdoctorp304hstnhatt.jar"
 
 A302_FILE="webosdoctorp302hstnhatt-3.0.2.jar"
 A304_FILE="webosdoctorp304hstnhatt-3.0.4.jar"
@@ -65,8 +71,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${A302_FILE} ] && $wget -c ${A302_JAR_URL} -O downloads/${A302_FILE}
-[ ! -f downloads/${A304_FILE} ] && $wget -c ${A304_JAR_URL} -O downloads/${A304_FILE}
+[ ! -f downloads/${A302_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A302_JAR_URL}" -O downloads/${A302_FILE}
+[ ! -f downloads/${A304_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A304_JAR_URL}" -O downloads/${A304_FILE}
 
 [ $(md5sum downloads/${A302_FILE} | cut -d \  -f 1) != ${A302_MD5} ] && \
         echo "${A302_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-att-veer-impersonate-wr-2.1.1
+++ b/scripts/meta-att-veer-impersonate-wr-2.1.1
@@ -5,7 +5,13 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W211_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W211_JAR_URL="/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar"
 
 W211_FILE="webosdoctorp160una-wr-2.1.1.jar"
 
@@ -61,7 +67,7 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W211_FILE} ] && $wget -c ${W211_JAR_URL} -O downloads/${W211_FILE}
+[ ! -f downloads/${W211_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W211_JAR_URL}" -O downloads/${W211_FILE}
 
 [ $(md5sum downloads/${W211_FILE} | cut -d \  -f 1) != ${W211_MD5} ] && \
         echo "${W211_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-bellmo-pre-2.1.0
+++ b/scripts/meta-bellmo-pre-2.1.0
@@ -6,9 +6,15 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d07142010/b11ep145rod/webosdoctorp100ewwbellmo.jar"
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d07142010/b11ep145rod/webosdoctorp100ewwbellmo.jar"
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W145_FILE="webosdoctorp100ewwbellmo-1.4.5.jar"
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
@@ -74,9 +80,9 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-o2-pre-2.1.0
+++ b/scripts/meta-o2-pre-2.1.0
@@ -6,7 +6,13 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
 
@@ -57,7 +63,7 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-o2-preplus-2.1.0
+++ b/scripts/meta-o2-preplus-2.1.0
@@ -6,7 +6,13 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
 
@@ -57,7 +63,7 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W210_FILE} | cut -d \  -f 1) != ${W210_MD5} ] && \
         echo "${W210_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-unlocked-pre2-2.1.0
+++ b/scripts/meta-sprint-franken-unlocked-pre2-2.1.0
@@ -6,8 +6,8 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
 W210_FILE="webosdoctorp103ueuna-wr-2.1.0.jar"
@@ -77,8 +77,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-unlocked-pre2-2.2.4
+++ b/scripts/meta-sprint-franken-unlocked-pre2-2.2.4
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -78,8 +84,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-verizon-pre2-2.1.0
+++ b/scripts/meta-sprint-franken-verizon-pre2-2.1.0
@@ -6,8 +6,8 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
 W210_FILE="webosdoctorp103ueuna-wr-2.1.0.jar"
@@ -79,8 +79,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-verizon-pre2-2.2.4
+++ b/scripts/meta-sprint-franken-verizon-pre2-2.2.4
@@ -9,7 +9,8 @@
 
 # Doctor server Domain and Host is now centralized in /meta-doctor/scripts/doctor-source
 # in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_HOST"
-# brought in with the "source" command below
+# Those variables are evaulated to produce "DOCTOR_SOURCE_OPTS_AND_DOMAIN"
+# brought in with the "source" command below and used in these scripts.
 
 source ./scripts/doctor-source
 
@@ -84,8 +85,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL} --header "Host: ${DOCTOR_SOURCE_HOST}" -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL} --header "Host: ${DOCTOR_SOURCE_HOST}" -O downloads/${W224_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget -c ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}${W224_JAR_URL} -O downloads/${W224_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-verizon-pre2-2.2.4
+++ b/scripts/meta-sprint-franken-verizon-pre2-2.2.4
@@ -7,9 +7,8 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-# Doctor server Domain and Host is now centralized in /meta-doctor/scripts/doctor-source
-# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_HOST"
-# Those variables are evaulated to produce "DOCTOR_SOURCE_OPTS_AND_DOMAIN"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
 # brought in with the "source" command below and used in these scripts.
 
 source ./scripts/doctor-source
@@ -85,8 +84,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${DOCTOR_SOURCE_OPTS_AND_DOMAIN}${W224_JAR_URL} -O downloads/${W224_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-verizon-pre2-2.2.4
+++ b/scripts/meta-sprint-franken-verizon-pre2-2.2.4
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+# Doctor server Domain and Host is now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_HOST"
+# brought in with the "source" comand below
+
+source ./scripts/doctor-source
+
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -78,8 +84,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL} --header "Host: ${DOCTOR_SOURCE_HOST}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget -c ${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL} --header "Host: ${DOCTOR_SOURCE_HOST}" -O downloads/${W224_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-franken-verizon-pre2-2.2.4
+++ b/scripts/meta-sprint-franken-verizon-pre2-2.2.4
@@ -9,7 +9,7 @@
 
 # Doctor server Domain and Host is now centralized in /meta-doctor/scripts/doctor-source
 # in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_HOST"
-# brought in with the "source" comand below
+# brought in with the "source" command below
 
 source ./scripts/doctor-source
 

--- a/scripts/meta-sprint-pre-1.4.5.1
+++ b/scripts/meta-sprint-pre-1.4.5.1
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
-S145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+S145_JAR_URL="/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
 
 V1451_FILE="webosdoctorp101ewwverizonwireless-1.4.5.1.jar"
 S145_FILE="webosdoctorp100ewwsprint-1.4.5.jar"
@@ -74,8 +80,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${S145_FILE} ]  && $wget -c ${S145_JAR_URL}  -O downloads/${S145_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${S145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${S145_JAR_URL}"  -O downloads/${S145_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${S145_FILE}  | cut -d \  -f 1) != ${S145_MD5} ]  && \
         echo "${S145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-sprint-pre-2.1.0
+++ b/scripts/meta-sprint-pre-2.1.0
@@ -6,10 +6,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 W145_FILE="webosdoctorp100ewwsprint-1.4.5.jar"
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
@@ -104,10 +110,10 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
 	echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-telcel-pre-2.1.0
+++ b/scripts/meta-telcel-pre-2.1.0
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W140_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p14r0d02252010/tce11p140rod/webosdoctorp100ewwtelcel.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W140_JAR_URL="/webosdoctor/rom/pre/p14r0d02252010/tce11p140rod/webosdoctorp100ewwtelcel.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W140_FILE="webosdoctorp100ewwtelcel-1.4.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -67,8 +73,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W140_FILE} ] && $wget -c ${W140_JAR_URL} -O downloads/${W140_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W140_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W140_JAR_URL}" -O downloads/${W140_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W140_FILE} | cut -d \  -f 1) != ${W140_MD5} ] && \
         echo "${W140_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-verizon-franken-unlocked-pre2-2.1.0
+++ b/scripts/meta-verizon-franken-unlocked-pre2-2.1.0
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
 W210_FILE="webosdoctorp103ueuna-wr-2.1.0.jar"
@@ -77,8 +83,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-verizon-preplus-2.1.0
+++ b/scripts/meta-verizon-preplus-2.1.0
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.1.0.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -96,8 +102,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-franken-sprint-pre-2.1.0
+++ b/scripts/meta-wr-franken-sprint-pre-2.1.0
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W145_FILE="webosdoctorp100ueu-wr-1.4.5.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -67,8 +73,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-pixiplus-1.4.5.1
+++ b/scripts/meta-wr-pixiplus-1.4.5.1
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+W145_JAR_URL="/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar"
 
 V1451_FILE="webosdoctorp121ewwverizonwireless-1.4.5.1.jar"
 W145_FILE="webosdoctorp121ewweu-wr-1.4.5.jar"
@@ -74,8 +80,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ]  && $wget -c ${W145_JAR_URL}  -O downloads/${W145_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}"  -O downloads/${W145_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W145_FILE}  | cut -d \  -f 1) != ${W145_MD5} ]  && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-pre-1.4.5.1
+++ b/scripts/meta-wr-pre-1.4.5.1
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
 
 V1451_FILE="webosdoctorp101ewwverizonwireless-1.4.5.1.jar"
 W145_FILE="webosdoctorp100ueu-wr-1.4.5.jar"
@@ -74,8 +80,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ]  && $wget -c ${W145_JAR_URL}  -O downloads/${W145_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}"  -O downloads/${W145_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W145_FILE}  | cut -d \  -f 1) != ${W145_MD5} ]  && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-pre-2.1.0
+++ b/scripts/meta-wr-pre-2.1.0
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W145_FILE="webosdoctorp100ueu-wr-1.4.5.jar"
 W210_FILE="webosdoctorp101ueu-wr-2.1.0.jar"
@@ -67,8 +73,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-pre3-impersonate-att-2.2.4
+++ b/scripts/meta-wr-pre3-impersonate-att-2.2.4
@@ -5,7 +5,13 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-A224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+A224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
 
 A224_FILE="webosdoctorp224mantaatt-2.2.4.jar"
 
@@ -61,7 +67,7 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${A224_FILE} ] && $wget -c ${A224_JAR_URL} -O downloads/${A224_FILE}
+[ ! -f downloads/${A224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A224_JAR_URL}" -O downloads/${A224_FILE}
 
 [ $(md5sum downloads/${A224_FILE} | cut -d \  -f 1) != ${A224_MD5} ] && \
         echo "${A224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-pre3-vanilla-2.2.3
+++ b/scripts/meta-wr-pre3-vanilla-2.2.3
@@ -5,8 +5,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W220_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
-A223_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W220_JAR_URL="/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar"
+A223_JAR_URL="/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar"
 
 W220_FILE="webosdoctorp220manta-wr-2.2.0.jar"
 A223_FILE="webosdoctorp223mantaatt-2.2.3.jar"
@@ -85,8 +91,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W220_FILE} ] && $wget -c ${W220_JAR_URL} -O downloads/${W220_FILE}
-[ ! -f downloads/${A223_FILE} ] && $wget -c ${A223_JAR_URL} -O downloads/${A223_FILE}
+[ ! -f downloads/${W220_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W220_JAR_URL}" -O downloads/${W220_FILE}
+[ ! -f downloads/${A223_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A223_JAR_URL}" -O downloads/${A223_FILE}
 
 [ $(md5sum downloads/${W220_FILE} | cut -d \  -f 1) != ${W220_MD5} ] && \
         echo "${W220_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/meta-wr-preplus-1.4.5.1
+++ b/scripts/meta-wr-preplus-1.4.5.1
@@ -6,8 +6,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p145r0d06302010/eudep145rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+W145_JAR_URL="/webosdoctor/rom/preplus/p145r0d06302010/eudep145rod/webosdoctorp101ueu-wr.jar"
 
 V1451_FILE="webosdoctorp101ewwverizonwireless-1.4.5.1.jar"
 W145_FILE="webosdoctorp101ueu-wr-1.4.5.jar"
@@ -74,8 +80,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ]  && $wget -c ${W145_JAR_URL}  -O downloads/${W145_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}"  -O downloads/${W145_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W145_FILE}  | cut -d \  -f 1) != ${W145_MD5} ]  && \
         echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/old-meta-sprint-pre-2.1.0
+++ b/scripts/old-meta-sprint-pre-2.1.0
@@ -6,9 +6,15 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W145_JAR_URL="/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 W145_FILE="webosdoctorp100ewwsprint-1.4.5.jar"
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
@@ -102,9 +108,9 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W145_FILE} ] && $wget -c ${W145_JAR_URL} -O downloads/${W145_FILE}
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W145_JAR_URL}" -O downloads/${W145_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W145_FILE} | cut -d \  -f 1) != ${W145_MD5} ] && \
 	echo "${W145_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/old-meta-verizon-pre2-2.1.0
+++ b/scripts/old-meta-verizon-pre2-2.1.0
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-CDMA_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+CDMA_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+W210_JAR_URL="/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar"
 
 CDMA_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
 W210_FILE="webosdoctorp103ueuna-wr-2.1.0.jar"
@@ -80,8 +86,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${CDMA_FILE} ] && $wget -c ${CDMA_JAR_URL} -O downloads/${CDMA_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${CDMA_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${CDMA_JAR_URL}" -O downloads/${CDMA_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${CDMA_FILE} | cut -d \  -f 1) != ${CDMA_MD5} ] && \
         echo "${CDMA_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/super-att-pixiplus-2.1.0
+++ b/scripts/super-att-pixiplus-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121pixiplus-att-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -84,10 +90,10 @@ mkdir -p downloads
 
 # $make clobber
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ -f ./downloads/${A210_FILE} ] || { echo "Not prepared for Super webOS 2.1.0 build" ; echo "Please run the Build Doctor first" ; exit ; }
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \

--- a/scripts/super-sprint-pixi-2.1.0
+++ b/scripts/super-sprint-pixi-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp200pixi-sprint-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -84,10 +90,10 @@ mkdir -p downloads
 
 # $make clobber
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ -f ./downloads/${S210_FILE} ] || { echo "Not prepared for Super webOS 2.1.0 build" ; echo "Please run the Build Doctor first" ; exit ; }
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \

--- a/scripts/super-veer-2.2.4
+++ b/scripts/super-veer-2.2.4
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
 V201_FILE="webosdoctorp102verizonwireless-2.0.1.jar"
@@ -108,10 +114,10 @@ echo
 mkdir -p downloads
 
 echo "Will download if needed webOS Doctors"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/super-verizon-pixiplus-2.1.0
+++ b/scripts/super-verizon-pixiplus-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121pixiplus-verizon-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -84,10 +90,10 @@ mkdir -p downloads
 
 # $make clobber
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ -f ./downloads/${V210_FILE} ] || { echo "Not prepared for Super webOS 2.1.0 build" ; echo "Please run the Build Doctor first" ; exit ; }
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \

--- a/scripts/super-verizon-pre2-2.2.4
+++ b/scripts/super-verizon-pre2-2.2.4
@@ -7,11 +7,17 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
 
 P224_FILE="webosdoctorp224pre2-verizon-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -116,11 +122,11 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/super-verizon-preplus-2.2.4
+++ b/scripts/super-verizon-preplus-2.2.4
@@ -7,12 +7,18 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
 
 P224_FILE="webosdoctorp224preplus-verizon-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -141,12 +147,12 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/super-wr-pixiplus-2.1.0
+++ b/scripts/super-wr-pixiplus-2.1.0
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
 
 P210_FILE="webosdoctorp121pixiplus-wr-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -84,10 +90,10 @@ mkdir -p downloads
 
 # $make clobber
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
 
 [ -f ./downloads/${W210_FILE} ] || { echo "Not prepared for Super webOS 2.1.0 build" ; echo "Please run the Build Doctor first" ; exit ; }
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \

--- a/scripts/test-att-preplus-2.2.4
+++ b/scripts/test-att-preplus-2.2.4
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-A224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+A224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaatt/webosdoctorp224mantaatt.jar"
 
 P224_FILE="webosdoctorp224preplus-att-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -135,10 +141,10 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${A224_FILE} ] && $wget -c ${A224_JAR_URL} -O downloads/${A224_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${A224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A224_JAR_URL}" -O downloads/${A224_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-bellmo-pre-2.2.4
+++ b/scripts/test-bellmo-pre-2.2.4
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-B145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d07142010/b11ep145rod/webosdoctorp100ewwbellmo.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+B145_JAR_URL="/webosdoctor/rom/pre/p145r0d07142010/b11ep145rod/webosdoctorp100ewwbellmo.jar"
 
 P224_FILE="webosdoctorp224pre-bellmo-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -116,10 +122,10 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${B145_FILE} ] && $wget -c ${B145_JAR_URL} -O downloads/${B145_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${B145_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${B145_JAR_URL}" -O downloads/${B145_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-sprint-pre-2.2.4
+++ b/scripts/test-sprint-pre-2.2.4
@@ -7,11 +7,17 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-S145_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+S145_JAR_URL="/webosdoctor/rom/pre/p145r0d08102010/spr1ntp145rod/webosdoctorp100ewwsprint.jar"
 
 P224_FILE="webosdoctorp224pre-sprint-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -140,11 +146,11 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${S145_FILE} ]  && $wget -c ${S145_JAR_URL}  -O downloads/${S145_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${S145_FILE} ]  && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${S145_JAR_URL}"  -O downloads/${S145_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-verizon-pixiplus-1.4.5.1
+++ b/scripts/test-verizon-pixiplus-1.4.5.1
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+V1451_JAR_URL="/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar"
 
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
 V1451_FILE="webosdoctorp121ewwverizonwireless-1.4.5.1.jar"
@@ -67,8 +73,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-verizon-pre2-2.1.0
+++ b/scripts/test-verizon-pre2-2.1.0
@@ -7,12 +7,18 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
 
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
 A212_FILE="webosdoctorp160unaatt-2.1.2.jar"
@@ -119,12 +125,12 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-verizon-pre2-2.2.4
+++ b/scripts/test-verizon-pre2-2.2.4
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
 
 P224_FILE="webosdoctorp224pre2-verizon-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -93,8 +99,8 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-verizon-preplus-2.1.0
+++ b/scripts/test-verizon-preplus-2.1.0
@@ -7,13 +7,19 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-A212_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
-V201_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
-V1451_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+A212_JAR_URL="/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+V201_JAR_URL="/webosdoctor/rom/pre2/p201r0d02172011/ver1z0np201rod/webosdoctorp102verizonwireless.jar"
+V1451_JAR_URL="/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar"
 
 P210_FILE="webosdoctorp101preplus-verizon-2.1.0.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -130,13 +136,13 @@ echo
 
 mkdir -p downloads
 
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${A212_FILE} ] && $wget -c ${A212_JAR_URL} -O downloads/${A212_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
-[ ! -f downloads/${V201_FILE} ] && $wget -c ${V201_JAR_URL} -O downloads/${V201_FILE}
-[ ! -f downloads/${V1451_FILE} ] && $wget -c ${V1451_JAR_URL} -O downloads/${V1451_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${A212_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${A212_JAR_URL}" -O downloads/${A212_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
+[ ! -f downloads/${V201_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V201_JAR_URL}" -O downloads/${V201_FILE}
+[ ! -f downloads/${V1451_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V1451_JAR_URL}" -O downloads/${V1451_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-verizon-preplus-2.2.4
+++ b/scripts/test-verizon-preplus-2.2.4
@@ -7,10 +7,16 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
-V224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
-V210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+V224_JAR_URL="/webosdoctor/rom/manta/p224r0d12192011/wdmantaverizon/webosdoctorp224mantaverizon.jar"
+V210_JAR_URL="/webosdoctor/rom/pre2/p210r0d08162011/ver1z0np210rod/webosdoctorp102verizonwireless.jar"
 
 P224_FILE="webosdoctorp224preplus-verizon-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -132,10 +138,10 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
-[ ! -f downloads/${V224_FILE} ] && $wget -c ${V224_JAR_URL} -O downloads/${V224_FILE}
-[ ! -f downloads/${V210_FILE} ] && $wget -c ${V210_JAR_URL} -O downloads/${V210_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
+[ ! -f downloads/${V224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V224_JAR_URL}" -O downloads/${V224_FILE}
+[ ! -f downloads/${V210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${V210_JAR_URL}" -O downloads/${V210_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \

--- a/scripts/test-wr-preplus-2.2.4
+++ b/scripts/test-wr-preplus-2.2.4
@@ -7,8 +7,14 @@
 
 [ -d scripts ] || { echo "Run the script from the meta-doctor directory, not the scripts directory" ; exit ; }
 
-W224_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
-W210_JAR_URL="http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
+# Doctor server Domain and wget options are now centralized in /meta-doctor/scripts/doctor-source
+# in the variables: "DOCTOR_SOURCE_DOMAIN" and "DOCTOR_SOURCE_WGET_OPTS" (Array)
+# brought in with the "source" command below and used in these scripts.
+
+source ./scripts/doctor-source
+
+W224_JAR_URL="/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar"
+W210_JAR_URL="/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar"
 
 P224_FILE="webosdoctorp224preplus-wr-2.2.4.jar"
 W224_FILE="webosdoctorp224pre2-wr-2.2.4.jar"
@@ -107,8 +113,8 @@ echo
 mkdir -p downloads
 
 echo "***** Download and unpack dependent JAR files *****"
-[ ! -f downloads/${W224_FILE} ] && $wget -c ${W224_JAR_URL} -O downloads/${W224_FILE}
-[ ! -f downloads/${W210_FILE} ] && $wget -c ${W210_JAR_URL} -O downloads/${W210_FILE}
+[ ! -f downloads/${W224_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W224_JAR_URL}" -O downloads/${W224_FILE}
+[ ! -f downloads/${W210_FILE} ] && $wget "${DOCTOR_SOURCE_WGET_OPTS[@]}" "${DOCTOR_SOURCE_DOMAIN}${W210_JAR_URL}" -O downloads/${W210_FILE}
 
 [ $(md5sum downloads/${W224_FILE} | cut -d \  -f 1) != ${W224_MD5} ] && \
         echo "${W224_FILE} did not download properly.  Please run this script again." && \


### PR DESCRIPTION
Removes hard-coded (Palm) URLs from all existing scripts and adds a single script file 
(scripts/doctor-source) that can be used to change the source of Doctors for all scripts.